### PR TITLE
✨ 로그인 및 AccessToken 재발급 api 구현

### DIFF
--- a/src/main/java/com/intern/onboarding/api/auth/AuthController.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthController.java
@@ -4,16 +4,16 @@ import com.intern.onboarding.api.auth.dto.SignInRequest;
 import com.intern.onboarding.api.auth.dto.SignInResponse;
 import com.intern.onboarding.api.auth.dto.SignUpRequest;
 import com.intern.onboarding.api.auth.dto.SignUpResponse;
+import com.intern.onboarding.exception.AccessDenied;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -44,5 +44,17 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(signInResponse);
+    }
+
+    @GetMapping("/token")
+    public ResponseEntity<SignInResponse> getToken(HttpServletRequest request) {
+        String refreshToken = Arrays.stream(request.getCookies())
+                .filter(c -> c.getName().equals("RefreshToken")).findFirst()
+                .orElseThrow(AccessDenied::new)
+                .getValue();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(authService.getNewAccessToken(refreshToken));
     }
 }

--- a/src/main/java/com/intern/onboarding/api/auth/AuthController.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthController.java
@@ -1,7 +1,11 @@
 package com.intern.onboarding.api.auth;
 
+import com.intern.onboarding.api.auth.dto.SignInRequest;
+import com.intern.onboarding.api.auth.dto.SignInResponse;
 import com.intern.onboarding.api.auth.dto.SignUpRequest;
 import com.intern.onboarding.api.auth.dto.SignUpResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -22,5 +27,22 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(authService.signUp(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<SignInResponse> login(@RequestBody SignInRequest request, HttpServletResponse response) {
+
+        SignInResponse signInResponse = authService.signIn(request);
+
+        String refreshToken = authService.generateRefreshToken(request);
+        Cookie cookie = new Cookie("RefreshToken", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(7 * 24 * 60 * 60);
+
+        response.addCookie(cookie);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(signInResponse);
     }
 }

--- a/src/main/java/com/intern/onboarding/api/auth/AuthService.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthService.java
@@ -11,4 +11,6 @@ public interface AuthService {
     SignInResponse signIn(SignInRequest request);
 
     String generateRefreshToken(SignInRequest request);
+
+    SignInResponse getNewAccessToken(String refreshToken);
 }

--- a/src/main/java/com/intern/onboarding/api/auth/AuthService.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthService.java
@@ -1,8 +1,14 @@
 package com.intern.onboarding.api.auth;
 
+import com.intern.onboarding.api.auth.dto.SignInRequest;
+import com.intern.onboarding.api.auth.dto.SignInResponse;
 import com.intern.onboarding.api.auth.dto.SignUpRequest;
 import com.intern.onboarding.api.auth.dto.SignUpResponse;
 
 public interface AuthService {
     SignUpResponse signUp(SignUpRequest request);
+
+    SignInResponse signIn(SignInRequest request);
+
+    String generateRefreshToken(SignInRequest request);
 }

--- a/src/main/java/com/intern/onboarding/api/auth/AuthServiceImpl.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthServiceImpl.java
@@ -1,10 +1,15 @@
 package com.intern.onboarding.api.auth;
 
+import com.intern.onboarding.api.auth.dto.SignInRequest;
+import com.intern.onboarding.api.auth.dto.SignInResponse;
 import com.intern.onboarding.api.auth.dto.SignUpRequest;
 import com.intern.onboarding.api.auth.dto.SignUpResponse;
+import com.intern.onboarding.domain.user.Role;
 import com.intern.onboarding.domain.user.User;
 import com.intern.onboarding.domain.user.UserRepository;
 import com.intern.onboarding.exception.AlreadyExistUsernameException;
+import com.intern.onboarding.exception.InvalidSignInException;
+import com.intern.onboarding.infra.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,6 +18,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
+    private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
 
@@ -24,5 +30,24 @@ public class AuthServiceImpl implements AuthService {
 
         User user = request.toEntity(passwordEncoder);
         return SignUpResponse.from(userRepository.save(user));
+    }
+
+    @Override
+    public SignInResponse signIn(SignInRequest request) {
+        User user = userRepository.findByUsername(request.username())
+                .orElseThrow(InvalidSignInException::new);
+
+        if (!user.checkPassword(request.password(), passwordEncoder))
+            throw new InvalidSignInException();
+
+        return new SignInResponse(jwtUtil.generateAccessToken(user.getId(), user.getRole()));
+    }
+
+    @Override
+    public String generateRefreshToken(SignInRequest request) {
+        User user = userRepository.findByUsername(request.username())
+                .orElseThrow(InvalidSignInException::new);
+
+        return jwtUtil.generateRefreshToken(user.getId(), user.getRole());
     }
 }

--- a/src/main/java/com/intern/onboarding/api/auth/AuthServiceImpl.java
+++ b/src/main/java/com/intern/onboarding/api/auth/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.intern.onboarding.exception.AlreadyExistUsernameException;
 import com.intern.onboarding.exception.InvalidSignInException;
 import com.intern.onboarding.exception.UnAuthorized;
 import com.intern.onboarding.infra.security.jwt.JwtUtil;
+import com.intern.onboarding.infra.security.jwt.TokenType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +58,8 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public SignInResponse getNewAccessToken(String refreshToken) {
         Jws<Claims> claimsJws = jwtUtil.validateToken(refreshToken).orElseThrow(UnAuthorized::new);
+        if (!TokenType.REFRESH_TOKEN.name().equals(claimsJws.getPayload().get("type"))) throw new UnAuthorized();
+
         Long id = Long.valueOf(claimsJws.getPayload().getSubject());
         Role role = Role.valueOf(claimsJws.getPayload().get("role", String.class));
 

--- a/src/main/java/com/intern/onboarding/api/auth/dto/SignInRequest.java
+++ b/src/main/java/com/intern/onboarding/api/auth/dto/SignInRequest.java
@@ -1,0 +1,4 @@
+package com.intern.onboarding.api.auth.dto;
+
+public record SignInRequest(String username, String password) {
+}

--- a/src/main/java/com/intern/onboarding/api/auth/dto/SignInResponse.java
+++ b/src/main/java/com/intern/onboarding/api/auth/dto/SignInResponse.java
@@ -1,0 +1,4 @@
+package com.intern.onboarding.api.auth.dto;
+
+public record SignInResponse(String token) {
+}

--- a/src/main/java/com/intern/onboarding/exception/AccessDenied.java
+++ b/src/main/java/com/intern/onboarding/exception/AccessDenied.java
@@ -1,0 +1,17 @@
+package com.intern.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AccessDenied extends CustomException {
+
+    private static final String MESSAGE = "접근 권한이 없습니다.";
+
+    public AccessDenied() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.FORBIDDEN.value();
+    }
+}

--- a/src/main/java/com/intern/onboarding/exception/InvalidSignInException.java
+++ b/src/main/java/com/intern/onboarding/exception/InvalidSignInException.java
@@ -1,0 +1,16 @@
+package com.intern.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidSignInException extends CustomException {
+    private static final String MESSAGE = "사용자명/비밀번호가 올바르지 않습니다.";
+
+    public InvalidSignInException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/src/main/java/com/intern/onboarding/exception/UnAuthorized.java
+++ b/src/main/java/com/intern/onboarding/exception/UnAuthorized.java
@@ -1,0 +1,17 @@
+package com.intern.onboarding.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnAuthorized extends CustomException {
+
+    private static final String MESSAGE = "인증 정보가 올바르지 않습니다.";
+
+    public UnAuthorized() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+}

--- a/src/main/java/com/intern/onboarding/infra/security/SecurityConfig.java
+++ b/src/main/java/com/intern/onboarding/infra/security/SecurityConfig.java
@@ -1,14 +1,16 @@
 package com.intern.onboarding.infra.security;
 
 import com.intern.onboarding.infra.security.jwt.JwtAuthenticationFilter;
+import com.intern.onboarding.infra.security.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +33,7 @@ public class SecurityConfig {
         return web -> web.ignoring()
                 .requestMatchers(toH2Console());
     }
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,7 +43,6 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(request ->
                         request.requestMatchers(
                                         "/api/auth/**",
@@ -49,6 +51,8 @@ public class SecurityConfig {
                                 ).permitAll()
                                 .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
                 .exceptionHandling(handler ->
                         handler.authenticationEntryPoint(authenticationEntryPoint)
                                 .accessDeniedHandler(accessDeniedHandler)

--- a/src/main/java/com/intern/onboarding/infra/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/intern/onboarding/infra/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.intern.onboarding.infra.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.intern.onboarding.exception.CustomException;
+import com.intern.onboarding.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            int statusCode = e.getStatusCode();
+
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setStatus(statusCode);
+
+            ErrorResponse error = new ErrorResponse(String.valueOf(statusCode), e.getMessage());
+            response.getWriter().write(new ObjectMapper().writeValueAsString(error));
+        }
+    }
+}

--- a/src/main/java/com/intern/onboarding/infra/security/jwt/JwtUtil.java
+++ b/src/main/java/com/intern/onboarding/infra/security/jwt/JwtUtil.java
@@ -37,14 +37,14 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(Long id, Role role) {
-        return generateToken(id, role, Duration.ofHours(accessTokenExpirationHour));
+        return generateToken(TokenType.ACCESS_TOKEN, id, role, Duration.ofHours(accessTokenExpirationHour));
     }
 
     public String generateRefreshToken(Long id, Role role) {
-        return generateToken(id, role, Duration.ofHours(refreshTokenExpirationHour));
+        return generateToken(TokenType.REFRESH_TOKEN, id, role, Duration.ofHours(refreshTokenExpirationHour));
     }
 
-    private String generateToken(Long id, Role role, Duration expirationPeriod) {
+    private String generateToken(TokenType type, Long id, Role role, Duration expirationPeriod) {
 
         Instant now = Instant.now();
 
@@ -54,6 +54,7 @@ public class JwtUtil {
                 .expiration(Date.from(now.plus(expirationPeriod)))
                 .subject(id.toString())
                 .claim("role", role)
+                .claim("type", type)
                 .signWith(key)
                 .compact();
     }

--- a/src/main/java/com/intern/onboarding/infra/security/jwt/TokenType.java
+++ b/src/main/java/com/intern/onboarding/infra/security/jwt/TokenType.java
@@ -1,0 +1,5 @@
+package com.intern.onboarding.infra.security.jwt;
+
+public enum TokenType {
+    ACCESS_TOKEN, REFRESH_TOKEN
+}


### PR DESCRIPTION
## 요약
로그인 / AccessToken 재발급 api 구현

## 작업사항
- 로그인 api 구현
  - 로그인시 reponse body로 AccessToken, http-only cookie로 RefreshToken 반환
- JwtExceptionFilter 추가
  -  JwtAuthenticationFilter에서 발생하는 예외처리
- AccessToken 재발급시에만 RefreshToken 사용되도록 구현