### PR TITLE
🔧 SecurityConfig - "/error" permitAll() 설정

### DIFF
--- a/src/main/java/com/intern/onboarding/infra/security/SecurityConfig.java
+++ b/src/main/java/com/intern/onboarding/infra/security/SecurityConfig.java
@@ -3,14 +3,13 @@ package com.intern.onboarding.infra.security;
 import com.intern.onboarding.infra.security.jwt.JwtAuthenticationFilter;
 import com.intern.onboarding.infra.security.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,19 +26,18 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public WebSecurityCustomizer customizer() {
         return web -> web.ignoring()
                 .requestMatchers(toH2Console());
     }
-    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -47,7 +45,8 @@ public class SecurityConfig {
                         request.requestMatchers(
                                         "/api/auth/**",
                                         "/swagger-ui/**",
-                                        "/v3/api-docs/**"
+                                        "/v3/api-docs/**",
+                                        "/error"
                                 ).permitAll()
                                 .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 요약
SecurityConfig 수정

## 작업사항
존재하지 않는 api에 요청시 상태 코드가 404가 아닌 401 발생
request에 대한 handler를 찾지못해 에러가 발생하자 "/error"로 리다이렉트되는데 "/error"는 permitAll()로 설정해 두지 않아 발생한 문제였다.

- "/error"를 securityConfig에서 permitAll()로 설정하여 해결